### PR TITLE
convert dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "main": "lib/cjs/index.js",
   "typings": "lib/cjs/index.d.ts",
   "types": "lib/cjs/index.d.ts",
-  "dependencies": {
-    "@cycle/react": "2.1.x",
+  "peerDependencies": {
+    "@cycle/react": "2.x.x",
     "react": ">=16.4.x",
     "react-dom": ">=16.4.x",
     "xstream": "11.x.x"


### PR DESCRIPTION
After merging https://github.com/cyclejs/react/pull/5, npm started to create `node_modules/@cycle/react-dom/node_modules/@cycle` with the old stuff (`react-dom/node_modules/@cycle/react/node_modules`...), because `cyclejs/react-dom` currently depends on cyclejs/react-dom v2.1.0, which in turn depends on React 16.5.2... This PR is for fixing the same issue - avoid nested npm installs of peer dependencies.